### PR TITLE
dezalgo onlistening

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var once = require('once')
 var portfinder = require('portfinder')
 var speedometer = require('speedometer')
 var thunky = require('thunky')
+var dezalgo = require('dezalgo');
 var Wire = require('bittorrent-protocol')
 
 // Use random port above 1024
@@ -400,7 +401,8 @@ Swarm.prototype.listen = function (port, onlistening) {
     port = undefined
   }
   if (this.listening) throw new Error('swarm already listening')
-  if (onlistening) this.once('listening', onlistening)
+  if (onlistening) this.once('listening', dezalgo(onlistening))
+
   debug('listen %s', port)
 
   var onPort = function (err, port) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "addr-to-ip-port": "^1.0.1",
     "bittorrent-protocol": "^1.2.0",
     "debug": "^2.0.0",
+    "dezalgo": "^1.0.1",
     "inherits": "^2.0.1",
     "once": "^1.3.0",
     "portfinder": "^0.3.0",


### PR DESCRIPTION
was using webtorrent and ran into a problem in webtorrent's add/download function - it sometimes runs the ontorrent callback before the function itself returns.

tracked it down to bittorrent-swarm's listen method, but ontorrent should be dezalgo'd too, i can put in a PR if you like