### PR TITLE
handle missing destroy callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ var portfinder = require('portfinder')
 var speedometer = require('speedometer')
 var thunky = require('thunky')
 var Wire = require('bittorrent-protocol')
+var dezalgo = require('dezalgo')
+
+function noop () {}
 
 // Use random port above 1024
 portfinder.basePort = Math.floor(Math.random() * 60000) + 1025
@@ -200,6 +203,7 @@ Pool.prototype._onerror = function (err) {
 Pool.prototype.destroy = function (cb) {
   // Destroy all open connections & wire objects so the server can gracefully
   // close without waiting for timeout or the remote peer to disconnect.
+  cb = dezalgo(cb || noop)
   this.conns.forEach(function (conn) {
     conn.destroy()
   })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "addr-to-ip-port": "^1.0.1",
     "bittorrent-protocol": "^1.2.0",
     "debug": "^2.0.0",
+    "dezalgo": "^1.0.1",
     "inherits": "^2.0.1",
     "once": "^1.3.0",
     "portfinder": "^0.3.0",


### PR DESCRIPTION
Pool.prototype.destroy throws err if this.server.close() throws an err and cb param is missing. Also a zalgo