### PR TITLE
Fix "TypeError: Cannot read property 'port' of null"

### DIFF
--- a/lib/tcp-pool.js
+++ b/lib/tcp-pool.js
@@ -156,7 +156,8 @@ TCPPool.prototype.destroy = function (cb) {
 
 TCPPool.prototype._onListening = function () {
   var self = this
-  var port = self.server.address().port
+  var address = self.server.address() || { port: 0 }
+  var port = address.port
 
   debug('tcp pool listening on %s', port)
 


### PR DESCRIPTION
I was getting an error when trying to run `npm test` in the main webtorrent repo:

```
TypeError: Cannot read property 'port' of null"
.../bittorrent-swarm/lib/tcp-pool.js:159
```

This seems to fix the error though I'm not sure why this was happening in the first place. `node v0.10.35`